### PR TITLE
[linux_aio] Fix events error handling in `AIOContext_process_events`

### DIFF
--- a/caio/linux_aio.c
+++ b/caio/linux_aio.c
@@ -256,7 +256,11 @@ static PyObject* AIOContext_process_events(
         ev = &events[i];
 
         op = (AIOOperation*) ev->data;
-        op->iocb.aio_nbytes = ev->res;
+        if (ev->res >= 0) {
+            op->iocb.aio_nbytes = ev->res;
+        } else {
+            op->error = -ev->res;
+        }
 
         if (op->callback == NULL) {
             continue;


### PR DESCRIPTION
Fix bad behaviour when data cannot be written (e.g. quota and prlimit violation).
In that case, old behaviour was to return negative error_code from read/write function. New behaviour is to raise SystemError with corresponding error code description.