### PR TITLE
fix: change python min version to 3.5 for pep440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
-    python_requires=">=3.5.*, <4",
+    python_requires=">=3.5, <4",
     extras_require={
         "develop": [
             "aiomisc",


### PR DESCRIPTION
Poetry complains about "*", and should mean the same without.

Thanks!