### PR TITLE
Fix cancelled operation triggering asyncio uncaught exception handler

### DIFF
--- a/caio/asyncio_base.py
+++ b/caio/asyncio_base.py
@@ -64,7 +64,9 @@ class AsyncioContextBase(abc.ABC):
         if future.done():
             return
 
-        self.loop.call_soon_threadsafe(future.set_result, True)
+        self.loop.call_soon_threadsafe(
+            lambda: future.done() or future.set_result(True)
+        )
 
     def read(
         self, nbytes: int, fd: int,


### PR DESCRIPTION
The asyncio uncaught exception handler can be triggered when operations are cancelled, causing an error to be printed to stderr.

AsyncioContextBase._on_done() schedules a cross-thread call to Future.set_result, but doesn't check that the future is still not done before the call later runs on the asyncio thread. This allows for an operation to be cancelled in between the initial done() check and the set_result() call, which then fails, triggering the uncaught exception handler.

This PR fixes this by re-checking if the Future is done before calling set_result().

I can imagine you don't necessarily need a test for this, as it's a deterministic thing, but putting in a test was the easiest way to reproduce/demonstrate the issue. You can see it failing for the current version by checking out the test commit and running:

```
$ pytest tests/test_asyncio_adapter.py::test_operations_cancel_cleanly
```

You should see the test fail, and  the captured output to stderr will contain errors logged by the asyncio uncaught exception handler like this:
```
Exception in callback Future.set_result(True)
handle: <Handle Future.set_result(True)>
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
asyncio.exceptions.InvalidStateError: invalid state
```

I'm getting these kind of errors logged by my app due to this (I'm doing something similar to the test here, reading a bunch of chunks from a file concurrently/eagerly, and at some point deciding to cancel the remaining read operations.