### PR TITLE
feat: Add PEP 517/518 build-system metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
* Add pyproject.toml with build-system table for setuptools as the build backend.
   - c.f. https://learn.scientific-python.org/development/guides/packaging-classic/