### PR TITLE
Add define for HAVE_FDATASYNC for threadpool and bump to 0.9.21

### DIFF
--- a/caio/linux_aio.c
+++ b/caio/linux_aio.c
@@ -943,6 +943,8 @@ static PyModuleDef linux_aio_module = {
 
 
 PyMODINIT_FUNC PyInit_linux_aio(void) {
+    Py_Initialize();
+
     struct utsname uname_data;
 
     if (uname(&uname_data)) {

--- a/caio/thread_aio.c
+++ b/caio/thread_aio.c
@@ -102,11 +102,11 @@ AIOContext_init(AIOContext *self, PyObject *args, PyObject *kwds)
         return -1;
     }
 
-    if (self->max_requests > MAX_QUEUE) {
+    if (self->max_requests >= (MAX_QUEUE - 1)) {
         PyErr_Format(
             PyExc_ValueError,
             "max_requests too large. Allowed lower then %d",
-            MAX_QUEUE
+            MAX_QUEUE - 1
         );
         return -1;
     }

--- a/caio/thread_aio.c
+++ b/caio/thread_aio.c
@@ -170,8 +170,13 @@ void worker(void *arg) {
             result = fsync(fileno);
             break;
         case THAIO_FDSYNC:
+#ifdef HAVE_FDATASYNC
             result = fdatasync(fileno);
+#else
+            result = fsync(fileno);
+#endif
             break;
+
         case THAIO_READ:
             result = pread(fileno, buf, buf_size, offset);
             break;

--- a/caio/thread_aio.c
+++ b/caio/thread_aio.c
@@ -808,7 +808,7 @@ static PyModuleDef thread_aio_module = {
 
 
 PyMODINIT_FUNC PyInit_thread_aio(void) {
-    PyEval_InitThreads();
+    Py_Initialize();
 
     PyObject *m;
 

--- a/caio/version.py
+++ b/caio/version.py
@@ -5,7 +5,7 @@ package_license = "Apache Software License"
 
 team_email = author_info[0][1]
 
-version_info = (0, 9, 20)
+version_info = (0, 9, 21)
 
 __author__ = ", ".join("{} <{}>".format(*info) for info in author_info)
 __version__ = ".".join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if "linux" in OS_NAME:
                 "{}/thread_aio.c".format(module_name),
                 "{}/src/threadpool/threadpool.c".format(module_name),
             ],
-            extra_compile_args=["-g"],
+            extra_compile_args=["-g", "-DHAVE_FDATASYNC"],
         ),
     )
 elif "darwin" in OS_NAME:
@@ -34,7 +34,7 @@ elif "darwin" in OS_NAME:
                 "{}/thread_aio.c".format(module_name),
                 "{}/src/threadpool/threadpool.c".format(module_name),
             ],
-            extra_compile_args=["-g", "-Wno-implicit-function-declaration"],
+            extra_compile_args=["-g"],
         ),
     )
 if "linux" in OS_NAME:


### PR DESCRIPTION
This merge request introduces several changes and improvements to the `caio` project. It focuses on enhancing compatibility, fixing edge cases, improving error handling, and updating versioning and build configurations.

---

## Changes

### 1. **Enhancements to Initialization**
- Added `Py_Initialize()` in both `linux_aio.c` and `thread_aio.c` to ensure the Python runtime is properly initialized before using the Python API.
- Replaced the deprecated `PyEval_InitThreads()` with `Py_Initialize()` in `thread_aio.c` for better compatibility with newer Python versions.

---

### 2. **Error Handling Updates**
- Updated the condition for `self->max_requests` in `thread_aio.c`:
  - Changed from `self->max_requests > MAX_QUEUE` to `self->max_requests >= (MAX_QUEUE - 1)`.
  - Updated error message to reflect the adjusted logic, ensuring clarity for users.

---

### 3. **Filesystem Synchronization (fdatasync)**
- Introduced conditional compilation for `fdatasync` in `thread_aio.c`:
  - If `HAVE_FDATASYNC` is defined, `fdatasync` will be used.
  - If not defined, fallback to `fsync` ensures functionality on systems where `fdatasync` is unavailable.

---

### 4. **Build Configuration Updates**
- Modified `setup.py`:
  - Added `-DHAVE_FDATASYNC` to `extra_compile_args` for Linux builds to enable conditional support for `fdatasync`.
  - Removed `-Wno-implicit-function-declaration` from macOS builds for cleaner warnings.

---

### 5. **Version Update**
- Bumped the version from `0.9.20` to `0.9.21` in `version.py` to reflect the changes and improvements.
