### PR TITLE
Fix pointer cast that breaks 32 bit builds

### DIFF
--- a/caio/linux_aio.c
+++ b/caio/linux_aio.c
@@ -596,7 +596,7 @@ static PyObject* AIOOperation_read(
     if (!argIsOk) return NULL;
 
     self->buffer = PyMem_Calloc(nbytes, sizeof(char));
-    self->iocb.aio_buf = (uint64_t) self->buffer;
+    self->iocb.aio_buf = (uint64_t)(uintptr_t) self->buffer;
     self->iocb.aio_nbytes = nbytes;
     self->py_buffer = PyMemoryView_FromMemory(self->buffer, nbytes, PyBUF_READ);
     self->iocb.aio_lio_opcode = IOCB_CMD_PREAD;
@@ -676,7 +676,7 @@ static PyObject* AIOOperation_write(
     Py_INCREF(self->py_buffer);
 
     self->iocb.aio_nbytes = nbytes;
-    self->iocb.aio_buf = (uint64_t) self->buffer;
+    self->iocb.aio_buf = (uint64_t)(uintptr_t) self->buffer;
 
     return (PyObject*) self;
 }


### PR DESCRIPTION
Fixes: https://github.com/mosquito/caio/issues/38  
See-Also: https://buildd.debian.org/status/fetch.php?pkg=caio&arch=armel&ver=0.9.21-2&stamp=1745049681&raw=0

With that change tests works for me on amd64, i386 and s390x