### PR TITLE
Modernize packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,10 @@ jobs:
           python-version: "3.9"
 
       - name: Install requires
-        run: python -m pip install twine wheel setuptools
+        run: python -m pip install twine build
 
       - name: Build source package
-        run: python setup.py sdist
+        run: python -m build --sdist
 
       - name: Publishing to pypi
         run: twine upload --skip-existing --disable-progress-bar dist/*.tar.gz
@@ -46,8 +46,6 @@ jobs:
       matrix:
         include:
           # MacOS
-          - python: '3.8'
-            os: macos-latest
           - python: '3.9'
             os: macos-latest
           - python: '3.10'
@@ -59,8 +57,6 @@ jobs:
           - python: '3.13'
             os: macos-latest
           # Windows
-          - python: '3.8'
-            os: windows-latest
           - python: '3.9'
             os: windows-latest
           - python: '3.10'
@@ -83,10 +79,10 @@ jobs:
           python-version: "${{ matrix.python }}"
 
       - name: Install requires
-        run: python -m pip install twine wheel setuptools
+        run: python -m pip install twine build
 
       - name: Build wheel for python "${{ matrix.python }}"
-        run: python setup.py bdist_wheel
+        run: python -m build --wheel
 
       - name: Publishing to pypi
         run: twine upload --skip-existing --disable-progress-bar dist/*.whl

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -45,9 +45,6 @@ jobs:
 
       matrix:
         include:
-          - toxenv: py38
-            python: "3.8"
-            os: ubuntu-latest
           - toxenv: py39
             python: "3.9"
             os: ubuntu-latest
@@ -63,9 +60,6 @@ jobs:
           - toxenv: py313
             python: "3.13"
             os: ubuntu-latest
-          - toxenv: py38
-            python: "3.8"
-            os: windows-latest
           - toxenv: py39
             python: "3.9"
             os: windows-latest
@@ -78,9 +72,6 @@ jobs:
           - toxenv: py313
             python: "3.13"
             os: windows-latest
-          - toxenv: py38
-            python: "3.8"
-            os: macos-latest
           - toxenv: py39
             python: "3.9"
             os: macos-latest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,1 @@
-include caio/*.pyi
-include caio/py.typed
 recursive-include caio/src/threadpool *.*
-include README.rst
-include LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,45 @@
 [build-system]
-requires = ["setuptools>=42"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "caio"
+license = "Apache-2.0"
+description = "Asynchronous file IO for Linux MacOS or Windows."
+readme = "README.md"
+authors = [{ name = "Dmitry Orlov", email = "me@mosquito.su"}]
+requires-python = ">=3.9"
+classifiers = [
+  "Topic :: Software Development",
+  "Topic :: Software Development :: Libraries",
+  "Intended Audience :: Developers",
+  "Natural Language :: English",
+  "Operating System :: MacOS",
+  "Operating System :: POSIX",
+  "Operating System :: Microsoft",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: Implementation :: CPython",
+]
+dynamic = ["version"]
+
+[project.urls]
+"Source Code" = "https://github.com/mosquito/caio/"
+
+[project.optional-dependencies]
+develop = [
+  "aiomisc-pytest",
+  "pytest",
+  "pytest-cov",
+]
+
+[tool.setuptools.packages.find]
+include = ["caio*"]
+
+[tool.setuptools.dynamic]
+version = { attr = "caio.version.__version__" }

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,9 @@
-import os
 import platform
-from importlib.machinery import SourceFileLoader
 
 from setuptools import Extension, setup
 
 
 module_name = "caio"
-module = SourceFileLoader(
-    "version", os.path.join(module_name, "version.py"),
-).load_module()
 
 
 OS_NAME = platform.system().lower()
@@ -48,53 +43,5 @@ if "linux" in OS_NAME:
 
 
 setup(
-    name=module_name,
-    version=module.__version__,
     ext_modules=extensions,
-    include_package_data=True,
-    description=module.package_info,
-    long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",
-    license=module.package_license,
-    author=module.__author__,
-    author_email=module.team_email,
-    package_data={
-        module_name: [
-            "{}/linux_aio.pyi".format(module_name),
-            "{}/thread_aio.pyi".format(module_name),
-            "py.typed",
-        ],
-    },
-    project_urls={
-        "Documentation": "https://github.com/mosquito/caio/",
-        "Source": "https://github.com/mosquito/caio",
-    },
-    packages=[module_name],
-    classifiers=[
-        "License :: OSI Approved :: Apache Software License",
-        "Topic :: Software Development",
-        "Topic :: Software Development :: Libraries",
-        "Intended Audience :: Developers",
-        "Natural Language :: English",
-        "Operating System :: MacOS",
-        "Operating System :: POSIX",
-        "Operating System :: Microsoft",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: Implementation :: CPython",
-    ],
-    python_requires=">=3.7, <4",
-    extras_require={
-        "develop": [
-            "aiomisc-pytest",
-            "pytest",
-            "pytest-cov",
-        ],
-    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py3{8-13}
+envlist = lint,py3{9-13}
 
 [testenv]
 passenv = COVERALLS_*, FORCE_COLOR
@@ -9,7 +9,7 @@ extras =
   develop
 
 commands=
-  py.test --cov=caio --cov-report=term-missing -sv tests
+  pytest --cov=caio --cov-report=term-missing -sv tests
 
 [testenv:lint]
 usedevelop = true
@@ -19,14 +19,6 @@ deps =
 
 commands=
   pylava -o pylava.ini .
-
-[testenv:checkdoc]
-deps =
-    collective.checkdocs
-    pygments
-
-commands =
-    python setup.py checkdocs
 
 [testenv:mypy]
 usedevelop = true


### PR DESCRIPTION
- Move static metadata from `setup.py` to `pyproject.toml`. _Side note: I'd recommend to remove the corresponding attributes from `caio/version.py`. They can be accessed via `importlib.metadata` if necessary.
- Add SPDX license identifier for PEP 639 license expression support.
- Require Python `>=3.9`, i.e. drop support for `3.8`. Setuptools `v77` (necessary for PEP 639 support) is only available on Python 3.9+. _If that's a dealbreaker at the moment, it would be possible to use the legacy `project.license.text` field for it instead._
- Remove unnecessary entries from `MANIFEST.in` as well as `include_package_data (the default with `pyproject.toml` configs)  and `package_data` => The files included in the sdist / wheel stay the same.
- Remove duplicate project url with different key. One link to the repo should probably be enough.
- Updated `tox.ini`
  - `py.test` should be replaced with `pytest`
  - Remove `python setup.py checkdocs`. I believe it isn't supported anymore.
_https://github.com/jaraco/pytest-checkdocs/ might be alternative, though I'm not sure that's necessary here._

Metadata diff
```diff
 ...
-Author: Dmitry Orlov <me@mosquito.su>
-Author-email: me@mosquito.su
+Author-email: Dmitry Orlov <me@mosquito.su>
-License: Apache Software License
+License-Expression: Apache-2.0
-Project-URL: Documentation, https://github.com/mosquito/caio/
-Project-URL: Source, https://github.com/mosquito/caio
+Project-URL: Source Code, https://github.com/mosquito/caio/
 ...
-Classifier: License :: OSI Approved :: Apache Software License
 ...
-Classifier: Programming Language :: Python :: 3.8
 ...
-Requires-Python: >=3.7, <4
+Requires-Python: >=3.9
```