### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "caio"
+license = "Apache-2.0"
 license-files = ["COPYING"]
 description = "Asynchronous file IO for Linux MacOS or Windows."
 readme = "README.md"


### PR DESCRIPTION
The license identifier got accidentally removed in #41 and wasn't added back in #42.
Followup to https://github.com/mosquito/caio/pull/41#pullrequestreview-2787923298