### PR TITLE
Include all files from the `tests` folder in the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ develop = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["caio*"]
+include = ["caio*", "tests"]
 
 [tool.setuptools.dynamic]
 version = { attr = "caio.version.__version__" }


### PR DESCRIPTION
Currently, `tests/conftest.py` is missing, makes it impossible to run tests from the sdist package.