### PR TITLE
Set explicit asyncio_default_fixture_loop_scope pytest option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ develop = [
   "setuptools",
 ]
 
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
+
 [tool.setuptools.packages.find]
 include = ["caio*"]
 


### PR DESCRIPTION
PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future.