### PR TITLE
fix duplicate license in the project.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "caio"
-license = "Apache-2.0"
 license-files = ["COPYING"]
 description = "Asynchronous file IO for Linux MacOS or Windows."
 readme = "README.md"


### PR DESCRIPTION
Due to duplicate licenses in the "project.toml" file, the installation in editable mode is broken, which may be related to the version of setuptools. But to retain compatibility, we will remove one of the license entries.