### PR TITLE
Remove inline for io_{cancel,submit}_error

### DIFF
--- a/caio/linux_aio.c
+++ b/caio/linux_aio.c
@@ -45,7 +45,7 @@ inline static long io_cancel(aio_context_t ctx, struct iocb *aiocb, struct io_ev
 }
 
 
-inline int io_cancel_error(int result) {
+int io_cancel_error(int result) {
     if (result == 0) return result;
 
     switch (errno) {
@@ -82,7 +82,7 @@ inline int io_cancel_error(int result) {
 }
 
 
-inline int io_submit_error(int result) {
+int io_submit_error(int result) {
     if (result >= 0) return result;
 
     switch (errno) {

--- a/caio/linux_aio.c
+++ b/caio/linux_aio.c
@@ -45,7 +45,7 @@ inline static long io_cancel(aio_context_t ctx, struct iocb *aiocb, struct io_ev
 }
 
 
-inline static io_cancel_error(int result) {
+inline static int io_cancel_error(int result) {
     if (result == 0) return result;
 
     switch (errno) {
@@ -82,7 +82,7 @@ inline static io_cancel_error(int result) {
 }
 
 
-inline static io_submit_error(int result) {
+inline static int io_submit_error(int result) {
     if (result >= 0) return result;
 
     switch (errno) {

--- a/caio/linux_aio.c
+++ b/caio/linux_aio.c
@@ -45,7 +45,7 @@ inline static long io_cancel(aio_context_t ctx, struct iocb *aiocb, struct io_ev
 }
 
 
-int io_cancel_error(int result) {
+inline static io_cancel_error(int result) {
     if (result == 0) return result;
 
     switch (errno) {
@@ -82,7 +82,7 @@ int io_cancel_error(int result) {
 }
 
 
-int io_submit_error(int result) {
+inline static io_submit_error(int result) {
     if (result >= 0) return result;
 
     switch (errno) {


### PR DESCRIPTION
We have builds in different operating systems and compilers. On AlmaLinux 9 with Clang 19 (and also others but not every combination that we try), importing `caio.linux_aio` fails because of two undefined symbols. Removing inline fixes the issue. I think it makes sense if they are to be used outside then they can't be inlined.

This is the error:

``` python
>>> import caio.linux_aio
ImportError: /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev3/Tue/caio/0.9.21/x86_64-el9-clang19-opt/lib/python3.13/site-packages/caio/linux_aio.cpython-313-x86_64-linux-gnu.so: undefined symbol: io_submit_error
```