### PR TITLE
Fix broken 0.12.0 Linux wheels: cp313-cp313t doesn't exist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,9 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
-        python: [cp310-cp310, cp311-cp311, cp312-cp312, cp313-cp313, cp314-cp314, cp313-cp313t, cp314-cp314t]
+        python: [cp310-cp310, cp311-cp311, cp312-cp312, cp313-cp313, cp314-cp314, cp314-cp314t]
     steps:
       - uses: actions/checkout@v4
       - name: Set version from release tag
@@ -60,8 +61,9 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
-        python: [cp310-cp310, cp311-cp311, cp312-cp312, cp313-cp313, cp314-cp314, cp313-cp313t, cp314-cp314t]
+        python: [cp310-cp310, cp311-cp311, cp312-cp312, cp313-cp313, cp314-cp314, cp314-cp314t]
     steps:
       - uses: actions/checkout@v4
       - name: Set version from release tag
@@ -86,8 +88,9 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
-        python: [cp310-cp310, cp311-cp311, cp312-cp312, cp313-cp313, cp314-cp314, cp313-cp313t, cp314-cp314t]
+        python: [cp310-cp310, cp311-cp311, cp312-cp312, cp313-cp313, cp314-cp314, cp314-cp314t]
     steps:
       - uses: actions/checkout@v4
       - name: Set version from release tag
@@ -123,8 +126,9 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
-        python: [cp310-cp310, cp311-cp311, cp312-cp312, cp313-cp313, cp314-cp314, cp313-cp313t, cp314-cp314t]
+        python: [cp310-cp310, cp311-cp311, cp312-cp312, cp313-cp313, cp314-cp314, cp314-cp314t]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
@@ -153,6 +157,7 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.13t", "3.14t"]
     steps:

--- a/scripts/make-wheels.sh
+++ b/scripts/make-wheels.sh
@@ -14,7 +14,6 @@ build_wheel cp311-cp311
 build_wheel cp312-cp312
 build_wheel cp313-cp313
 build_wheel cp314-cp314
-build_wheel cp313-cp313t
 build_wheel cp314-cp314t
 
 cd dist


### PR DESCRIPTION
## Summary

The 0.12.0 release's Linux wheel jobs are almost entirely broken - confirmed by pulling `quay.io/pypa/manylinux_2_34_x86_64` and `quay.io/pypa/musllinux_1_2_x86_64` directly and listing `/opt/python/`:

```
cp310-cp310  cp311-cp311  cp312-cp312  cp313-cp313  cp314-cp314  cp314-cp314t  cp315-cp315  cp315-cp315t  cp39-cp39
```

There's no `cp313-cp313t` in either image - only `cp314-cp314t` ships a free-threaded build. Every `wheels-linux-*`/`wheels-musllinux-*` job tried `/opt/python/cp313-cp313t/bin/pip` anyway, got "No such file or directory" (exit 127), and the default `fail-fast: true` matrix strategy cancelled every other Python version in that same job right along with it. Only macOS, Windows, and sdist made it onto the 0.12.0 release - all four Linux wheel jobs came back essentially empty.

## Fix

- Drop `cp313-cp313t` from the Linux matrices in `publish.yml` and `scripts/make-wheels.sh` (`cp314-cp314t` stays - it actually built successfully on 0.12.0).
- Add `fail-fast: false` to every wheel job's matrix strategy, so one bad Python version can't take its siblings down with it again.

## Recovering the 0.12.0 release

This branch only fixes the workflow going forward - it doesn't retroactively fix the already-published 0.12.0 release, which is still missing most Linux wheels. Once this merges, the release needs to actually get its wheels rebuilt and uploaded - happy to handle whichever way you'd prefer (re-tag, a fresh 0.12.1, or manually building+uploading to the existing release), just didn't want to touch the published release without checking first.

## Test plan

- [x] Confirmed the missing interpreter directly by pulling both images and listing `/opt/python/`
- [x] YAML validated with `yaml.safe_load`
