### PR TITLE
Don't install the test suite into site-packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 recursive-include caio/src/threadpool *.*
+graft tests
+global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ develop = [
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.setuptools.packages.find]
-include = ["caio*", "tests"]
+include = ["caio*"]
 
 [tool.ruff]
 line-length = 80


### PR DESCRIPTION
PR #45 set out to make the test suite runnable from the sdist,  via `[tool.setuptools.packages.find]`, which
declares *installable* packages. So `tests` also became a top-level package
shipped in every wheel and installed into `site-packages`.

This keeps #45's outcome and drops the side effect.
Installing `caio` 0.11.1 or later creates `site-packages/tests/` with 11 entries:

```
tests/conftest.py                      tests/test_operation_refcounting.py
tests/test_aio_context.py              tests/test_python_aio_callback.py
tests/test_asyncio_adapter.py          tests/test_raw_low_level.py
tests/test_free_threading.py           tests/test_thread_aio_specific.py
tests/test_impl_selector.py            tests/test_thread_aio_windows.py
```

Two consequences worth flagging:

- 10 of those files are listed in the wheel's `RECORD`, so `pip uninstall caio`
  deletes `site-packages/tests/*`, including files another distribution may
  have put there.
- `tests/` has no `__init__.py`, and `packages.find` defaults to
  `namespaces = true`. It therefore installs as an implicit **namespace**
  package named `tests`, which silently merges with any other top-level `tests`
  on `sys.path` instead of throwing conflicts.

Any two packages both shipping a top-level `tests` will clobber each other with
no warning from pip.

## The suggested changes

```diff
# pyproject.toml
 [tool.setuptools.packages.find]
-include = ["caio*", "tests"]
+include = ["caio*"]
```

```diff
# MANIFEST.in
 recursive-include caio/src/threadpool *.*
+graft tests
+global-exclude *.py[cod]
```

sdist contents are handled by `MANIFEST.in`. `graft` and `global-exclude` to keep stray bytecode out of the tarball.
This change should keep the intended functionality of #45 while not including the test suite in the top-level site-packages.

## Test of the changes
Building the sdist in the pure-revert state — `include = ["caio*"]` with
`MANIFEST.in` untouched — ships the 9 `tests/test_*.py` files but **not**
`tests/conftest.py`. Running the suite from that sdist gives the expected issue:

```
tests/test_raw_low_level.py:21: from conftest import drain
E   ModuleNotFoundError: No module named 'conftest'
ERROR tests/test_operation_refcounting.py
ERROR tests/test_raw_low_level.py
!!! Interrupted: 2 errors during collection !!!
```

When I built both artifacts locally from this branch:

- wheel top-level entries: `caio`, `caio-<ver>.dist-info` — `top_level.txt` is
  just `caio`, and 0 entries under `tests/`
- sdist still ships all 10 files under `tests/`, `conftest.py` included
- `pytest tests` from the extracted sdist: **239 passed, 511 skipped, 0 failed**
  (skips are the free-threading tests, which need a `3.13t`/`3.14t`
  interpreter, plus Windows-only paths)
- `import tests` after installing either the wheel or the sdist: `ImportError`

---

Found while pinning `caio` back to 0.9.25 downstream: the top-level `tests`
package shadowed our own `tests` namespace and silently disabled a
first-party import override. Affects 0.11.0 onward (first published in 0.11.1).

Let me know if there is things you would like to add - could add a check in the CI where we can catch a regression where tests is re-added to the top-level packages.