### PR TITLE
Fixes for less common platforms

### DIFF
--- a/caio/linux_aio.c
+++ b/caio/linux_aio.c
@@ -257,8 +257,9 @@ static PyObject* AIOContext_repr(AIOContext *self) {
         return NULL;
     }
     return PyUnicode_FromFormat(
-        "<%s as %p: max_requests=%i, ctx=%lli>",
-        Py_TYPE(self)->tp_name, self, self->max_requests, self->ctx
+        "<%s as %p: max_requests=%u, ctx=%llu>",
+        Py_TYPE(self)->tp_name, self, self->max_requests,
+        (unsigned long long) self->ctx
     );
 }
 
@@ -628,7 +629,7 @@ static PyMemberDef AIOContext_members[] = {
     },
     {
         "max_requests",
-        T_USHORT,
+        T_UINT,
         offsetof(AIOContext, max_requests),
         READONLY,
         "max requests"
@@ -744,9 +745,11 @@ static PyObject* AIOOperation_repr(AIOOperation *self) {
     }
 
     return PyUnicode_FromFormat(
-        "<%s at %p: mode=\"%s\", fd=%i, offset=%i, buffer=%p>",
+        "<%s at %p: mode=\"%s\", fd=%u, offset=%lld, buffer=%p>",
         Py_TYPE(self)->tp_name, self, mode,
-        self->iocb.aio_fildes, self->iocb.aio_offset, self->iocb.aio_buf
+        self->iocb.aio_fildes,
+        (long long) self->iocb.aio_offset,
+        (void *)(uintptr_t) self->iocb.aio_buf
     );
 }
 

--- a/caio/linux_aio.c
+++ b/caio/linux_aio.c
@@ -804,12 +804,21 @@ static PyObject* AIOOperation_read(
         return NULL;
     }
 
+    if (nbytes > (uint64_t) PY_SSIZE_T_MAX) {
+        Py_DECREF(self);
+        PyErr_SetString(
+            PyExc_OverflowError,
+            "nbytes does not fit in Py_ssize_t"
+        );
+        return NULL;
+    }
+
     /* PyMem_Calloc can return NULL for a large enough (or just OOM-at-the-
      * time) nbytes - proceeding with a NULL buf would hand the kernel (via
      * aio_buf) and PyMemoryView_FromMemory a NULL pointer with a nonzero
      * declared size, corrupting memory instead of raising a catchable
      * error. */
-    self->buffer = PyMem_Calloc(nbytes, sizeof(char));
+    self->buffer = PyMem_Calloc((size_t) nbytes, sizeof(char));
     if (self->buffer == NULL && nbytes > 0) {
         Py_DECREF(self);
         PyErr_NoMemory();
@@ -817,7 +826,9 @@ static PyObject* AIOOperation_read(
     }
     self->iocb.aio_buf = (uint64_t)(uintptr_t) self->buffer;
     self->iocb.aio_nbytes = nbytes;
-    self->py_buffer = PyMemoryView_FromMemory(self->buffer, nbytes, PyBUF_READ);
+    self->py_buffer = PyMemoryView_FromMemory(
+        self->buffer, (Py_ssize_t) nbytes, PyBUF_READ
+    );
     if (self->py_buffer == NULL) {
         Py_DECREF(self);
         return NULL;

--- a/caio/linux_aio.c
+++ b/caio/linux_aio.c
@@ -45,6 +45,12 @@ static const unsigned CTX_MAX_REQUESTS_DEFAULT = 32;
 static const unsigned EV_MAX_REQUESTS_DEFAULT = 512;
 static int kernel_support = -1;
 
+/* Raw io_getevents uses the kernel's two-long timeout layout. */
+struct caio_timespec {
+    long tv_sec;
+    long tv_nsec;
+};
+
 inline static int io_setup(unsigned nr, aio_context_t *ctxp) {
     return syscall(__NR_io_setup, nr, ctxp);
 }
@@ -57,7 +63,7 @@ inline static int io_destroy(aio_context_t ctx) {
 
 inline static int io_getevents(
     aio_context_t ctx, long min_nr, long max_nr,
-    struct io_event *events, struct timespec *timeout
+    struct io_event *events, struct caio_timespec *timeout
 ) {
     return syscall(__NR_io_getevents, ctx, min_nr, max_nr, events, timeout);
 }
@@ -463,7 +469,7 @@ static PyObject* AIOContext_process_events(
     uint32_t min_requests = 0;
     uint32_t max_requests = 0;
     int32_t tv_sec = 0;
-    struct timespec timeout = {0, 0};
+    struct caio_timespec timeout = {0, 0};
 
     static char *kwlist[] = {"max_requests", "min_requests", "timeout", NULL};
 
@@ -477,7 +483,7 @@ static PyObject* AIOContext_process_events(
      * (unlike linux_uring, whose io_uring_enter() has no native timeout
      * parameter at all). timeout=0 is a non-blocking check; timeout>0
      * bounds the wait. */
-    struct timespec *timeout_arg = NULL;
+    struct caio_timespec *timeout_arg = NULL;
     if (tv_sec >= 0) {
         timeout.tv_sec = tv_sec;
         timeout_arg = &timeout;

--- a/caio/linux_uring.c
+++ b/caio/linux_uring.c
@@ -219,6 +219,15 @@ static PyObject *AIOOperation_read(
         return NULL;
     }
 
+    if (nbytes > UINT32_MAX || nbytes > (uint64_t) PY_SSIZE_T_MAX) {
+        Py_DECREF(self);
+        PyErr_SetString(
+            PyExc_OverflowError,
+            "nbytes exceeds the io_uring read limit"
+        );
+        return NULL;
+    }
+
     /* Allocate the result bytes object directly — the kernel writes into
      * its internal buffer, so get_value() can return it with no copy.
      * PyBytes_FromStringAndSize(NULL, n) leaves the memory uninitialized

--- a/caio/linux_uring.c
+++ b/caio/linux_uring.c
@@ -682,8 +682,8 @@ static int AIOContext_init(AIOContext *self, PyObject *args, PyObject *kwds) {
      *
      * Opt-in (sqpoll=True): SQPOLL kernel thread polls SQ ring; io_uring_enter
      *   only needed to wake a sleeping thread.  Eliminates per-op syscall
-     *   overhead at sustained high QD.  EPERM on pre-5.11 kernels without
-     *   CAP_SYS_NICE is treated like EINVAL (try next entry).
+     *   overhead at sustained high QD.  Permission errors are treated like
+     *   EINVAL (try next entry), allowing fallback to a plain ring.
      *
      * IORING_SETUP_SINGLE_ISSUER deliberately never tried: it pins the ring
      * to whichever thread's io_uring_setup()/io_uring_enter() call created
@@ -719,7 +719,7 @@ static int AIOContext_init(AIOContext *self, PyObject *args, PyObject *kwds) {
             flags_used = params.flags;
             break;
         }
-        if (errno != EINVAL && errno != EPERM) {
+        if (errno != EINVAL && errno != EPERM && errno != EACCES) {
             PyErr_SetFromErrno(PyExc_SystemError);
             return -1;
         }

--- a/caio/thread_aio.c
+++ b/caio/thread_aio.c
@@ -637,18 +637,27 @@ static PyObject* AIOOperation_read(
         return NULL;
     }
 
+    if (nbytes > (uint64_t) PY_SSIZE_T_MAX) {
+        Py_DECREF(self);
+        PyErr_SetString(
+            PyExc_OverflowError,
+            "nbytes does not fit in Py_ssize_t"
+        );
+        return NULL;
+    }
+
     // PyMem_Calloc can return NULL for a large enough (or just
     // OOM-at-the-time) nbytes - proceeding with a NULL buf would hand the
     // kernel (via pread() in worker()) and PyMemoryView_FromMemory a NULL
     // pointer with a nonzero declared size, corrupting memory instead of
     // raising a catchable error.
-    self->buf = PyMem_Calloc(nbytes, sizeof(char));
+    self->buf = PyMem_Calloc((size_t) nbytes, sizeof(char));
     if (self->buf == NULL && nbytes > 0) {
         Py_DECREF(self);
         PyErr_NoMemory();
         return NULL;
     }
-    self->buf_size = nbytes;
+    self->buf_size = (Py_ssize_t) nbytes;
 
     self->py_buffer = PyMemoryView_FromMemory(
         self->buf,
@@ -993,7 +1002,7 @@ static PyMemberDef AIOOperation_members[] = {
         READONLY, "offset"
     },
     {
-        "nbytes", T_ULONGLONG,
+        "nbytes", T_PYSSIZET,
         offsetof(AIOOperation, buf_size),
         READONLY, "nbytes"
     },

--- a/caio/thread_aio.c
+++ b/caio/thread_aio.c
@@ -47,7 +47,7 @@ typedef struct {
     PyObject_HEAD
     threadpool_t* pool;
     uint16_t max_requests;
-    uint8_t pool_size;
+    uint16_t pool_size;
     PyObject* weakreflist;
 } AIOContext;
 
@@ -153,6 +153,7 @@ AIOContext_init(AIOContext *self, PyObject *args, PyObject *kwds)
 
     self->pool = NULL;
     self->max_requests = 0;
+    self->pool_size = 0;
 
     if (!PyArg_ParseTupleAndKeywords(
             args, kwds, "|HH", kwlist,
@@ -205,9 +206,9 @@ static PyObject* AIOContext_repr(AIOContext *self) {
         return NULL;
     }
     return PyUnicode_FromFormat(
-        "<%s as %p: max_requests=%i, pool_size=%i, ctx=%lli>",
+        "<%s as %p: max_requests=%u, pool_size=%u, ctx=%p>",
         Py_TYPE(self)->tp_name, self, self->max_requests,
-        self->pool_size, self->pool
+        self->pool_size, (void *) self->pool
     );
 }
 
@@ -456,7 +457,7 @@ static PyObject* AIOContext_close(
 static PyMemberDef AIOContext_members[] = {
     {
         "pool_size",
-        T_INT,
+        T_USHORT,
         offsetof(AIOContext, pool_size),
         READONLY,
         "pool_size"
@@ -581,9 +582,9 @@ static PyObject* AIOOperation_repr(AIOOperation *self) {
     }
 
     return PyUnicode_FromFormat(
-        "<%s at %p: mode=\"%s\", fd=%i, offset=%i, result=%i, buffer=%p>",
+        "<%s at %p: mode=\"%s\", fd=%u, offset=%lld, result=%d, buffer=%p>",
         Py_TYPE(self)->tp_name, self, mode,
-        self->fileno, self->offset, self->result, self->buf
+        self->fileno, (long long) self->offset, self->result, self->buf
     );
 }
 

--- a/tests/test_aio_context.py
+++ b/tests/test_aio_context.py
@@ -10,7 +10,7 @@ def test_aio_context(context_maker):
     ctx = context_maker(1)
     assert ctx is not None
 
-    ctx = context_maker(32218)
+    ctx = context_maker(128)
     assert ctx is not None
 
 

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -44,7 +44,7 @@ def test_high_concurrency_stress_no_data_races(tmp_path, submit_and_wait):
     fd = os.open(str(path), os.O_RDWR | _O_BINARY)
     ctx = None
     try:
-        ctx = python_aio.Context(max_requests=count, pool_size=32)
+        ctx = python_aio.Context(max_requests=count, pool_size=8)
         expected = [bytes([i % 256]) * chunk for i in range(count)]
 
         writes = (

--- a/tests/test_raw_low_level.py
+++ b/tests/test_raw_low_level.py
@@ -455,8 +455,8 @@ def test_uring_context_stays_alive_via_operation_while_genuinely_in_flight(tmp_p
 
     r_fd, w_fd = os.pipe()
     try:
-        fcntl.fcntl(w_fd, F_SETPIPE_SZ, 4096)
-        os.write(w_fd, b"f" * 4096)  # fill the pipe so the next write blocks until drained
+        pipe_size = fcntl.fcntl(w_fd, F_SETPIPE_SZ, 4096)
+        os.write(w_fd, b"f" * pipe_size)  # fill the pipe so the next write blocks until drained
 
         ctx = linux_uring.Context(max_requests=8)
         ctx_ref = weakref.ref(ctx)
@@ -476,7 +476,7 @@ def test_uring_context_stays_alive_via_operation_while_genuinely_in_flight(tmp_p
             "in flight - op.context should have kept it alive"
         )
 
-        os.read(r_fd, 8192)  # unblocks the pending write
+        os.read(r_fd, pipe_size)  # unblocks the pending write
         drain(ctx_ref(), 1, timeout=5.0)
         assert op.get_value() == len(b"pending")
 
@@ -1008,7 +1008,7 @@ def test_process_events_negative_timeout_waits_indefinitely(tmp_path, polling_ba
         def wait():
             result["n"] = ctx.process_events(min_requests=1, timeout=-1)
 
-        t = threading.Thread(target=wait)
+        t = threading.Thread(target=wait, daemon=True)
         t.start()
         try:
             t.join(timeout=0.3)
@@ -1058,8 +1058,8 @@ def test_uring_process_events_max_requests_bounds_callbacks_not_just_return_valu
     pipes = [os.pipe() for _ in range(5)]
     try:
         for r_fd, w_fd in pipes:
-            fcntl.fcntl(w_fd, F_SETPIPE_SZ, 4096)
-            os.write(w_fd, b"f" * 4096)  # fill each pipe so the next write blocks
+            pipe_size = fcntl.fcntl(w_fd, F_SETPIPE_SZ, 4096)
+            os.write(w_fd, b"f" * pipe_size)  # fill each pipe so the next write blocks
 
         ctx = linux_uring.Context(max_requests=16)
         called = []
@@ -1078,7 +1078,7 @@ def test_uring_process_events_max_requests_bounds_callbacks_not_just_return_valu
         )
 
         for r_fd, _w_fd in pipes:
-            os.read(r_fd, 8192)
+            os.read(r_fd, pipe_size)
         time.sleep(0.05)  # let the kernel actually post the completions
 
         first = ctx.process_events(max_requests=1, min_requests=0, timeout=0)
@@ -1122,8 +1122,8 @@ def test_uring_process_events_min_requests_ignores_cancel_sentinel(tmp_path):
         fd = f.fileno()
         r_fd, w_fd = os.pipe()
         try:
-            fcntl.fcntl(w_fd, F_SETPIPE_SZ, 4096)
-            os.write(w_fd, b"f" * 4096)  # fill the pipe so the next write blocks
+            pipe_size = fcntl.fcntl(w_fd, F_SETPIPE_SZ, 4096)
+            os.write(w_fd, b"f" * pipe_size)  # fill the pipe so the next write blocks
 
             ctx = linux_uring.Context(max_requests=16)
 
@@ -1150,7 +1150,7 @@ def test_uring_process_events_min_requests_ignores_cancel_sentinel(tmp_path):
             def drain_pipe_late():
                 time.sleep(0.2)
                 drained_before_call_returned.set()
-                os.read(r_fd, 8192)
+                os.read(r_fd, pipe_size)
 
             t = threading.Thread(target=drain_pipe_late)
             t.start()


### PR DESCRIPTION
Hello!

Here are fixes for issues affecting less-common platforms found via Debian tests [1]

d4e0572 fixes incorrect C type handling on big-endian arches. Tested in an s390x vm.
9381d9f fixes buffer-size handling on 32-bit architectures. Tested in an i386 docker container on an amd64 host and in a powerpc vm
39b7ba5 fixes timeout handling on 32-bit big-endian powerpc. Tested in a powerpc vm.
d663292 relaxes test assumptions that caused failures on alpha and loong64. Tested in a loong64 vm. I hope it will work for alpha too.
ac16a6b fixes the SQPOLL fallback when io_uring_setup() is denied in restricted environments, as observed in Debian's amd64 autopkgtests [2].

The last issue can be reproduced with:

```
strace -f -qq -o /dev/null \
    -e trace=io_uring_setup \
    --inject=io_uring_setup:error=EACCES:when=3 \
    dpkg-buildpackage # (or pytest...)
```

[1] https://buildd.debian.org/status/package.php?p=caio
[2] https://ci.debian.net/packages/c/caio/testing/amd64/74855165/