### PR TITLE
Fix pypy builds

### DIFF
--- a/caio/linux_aio.c
+++ b/caio/linux_aio.c
@@ -1247,8 +1247,6 @@ static PyModuleDef linux_aio_module = {
 
 
 PyMODINIT_FUNC PyInit_linux_aio(void) {
-    Py_Initialize();
-
     struct utsname uname_data;
 
     if (uname(&uname_data)) {

--- a/caio/thread_aio.c
+++ b/caio/thread_aio.c
@@ -1081,8 +1081,6 @@ static PyModuleDef thread_aio_module = {
 
 
 PyMODINIT_FUNC PyInit_thread_aio(void) {
-    Py_Initialize();
-
     PyObject *m;
 
     m = PyModule_Create(&thread_aio_module);


### PR DESCRIPTION
After updating dependencies in apt-mirror2, our pypy CI job failed while building caio 0.9.25:

```
caio/thread_aio.c:811: error: implicit declaration of function ‘Py_Initialize’
```

Pypy does not declare this function in its C api headers.

These calls appear unnecessary: the documentation describes `PyInit_*` as an entry point called during module import, and its embedding example initializes the interpreter before importing the extension [1].
Calling `Py_Initialize()` again without an intervening `Py_FinalizeEx()` has no effect on CPython [2].

This patch removes the calls from the thread and Linux AIO module initializers.

[1] https://docs.python.org/3.14/extending/extending.html#the-module-s-method-table-and-initialization-function
[2] https://docs.python.org/3.14/c-api/interp-lifecycle.html#c.Py_Initialize
